### PR TITLE
Add option '-a' to list installed licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ npm install --global @captainsafia/legit
 
     -h, --help               output usage information
     -V, --version            output the version number
+    -a, --list-all           List installed licenses
     -l, --license <license>  The license to include
     -u, --user <user>        The individual who owns the license
     -y, --year <year>        The year the license is effective

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function validateLicense(license) {
 program
   .version('1.0.0')
   .usage('[options]')
+  .option('-a, --list-all', 'List installed licenses')
   .option('-l, --license <license>', 'The license to include', validateLicense)
   .option('-u, --user <user>', 'The individual who owns the license')
   .option('-y, --year <year>', 'The year the license is effective')
@@ -36,6 +37,12 @@ if (program.license) {
       program.help();
     }
   });
+} else if (program.listAll) {
+    fs.readdir(__dirname + '/licenses/', function(err, items) {
+        for (var i=0; i<items.length; i++) {
+            console.log(items[i].slice(0, -4));
+        }
+    })
 } else {
   program.help();
 }


### PR DESCRIPTION
Thanks for releasing this! This is my first attempt at javascript, let alone CLI javascript, so feel free to refactor or steal this and make it better ☺️

I thought it would be cool to be able to see a list of installed licenses, so you could choose before you write one to `$PWD/LICENSE`. It ends up looking like this:

```shell
$ legit -a 
agpl3
apache2
mit
mpl2
$ legit --list-all
...
...
```