### PR TITLE
Attempt to read values from package.json in cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var user = program.user;
 if (!license || !user) {
   try {
     const packageJson = require(path.join(process.cwd(), 'package.json'));
-    if (!license && packageJson.license) license = packageJson.license.toLowerCase();
+    if (!license && packageJson.license) license = packageJson.license;
     
     if (!user && packageJson.author) {
       if (typeof packageJson.author === 'string') {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ var user = program.user;
 if (!license || !user) {
   try {
     const packageJson = require(path.join(process.cwd(), 'package.json'));
-    if (!license && packageJson.license) license = packageJson.license;
+    if (!license && packageJson.license) license = validateLicense(packageJson.license);
     
     if (!user && packageJson.author) {
       if (typeof packageJson.author === 'string') {

--- a/index.js
+++ b/index.js
@@ -27,19 +27,21 @@ program
 var license = program.license;
 var user = program.user;
 
-try {
-  const packageJson = require(path.join(process.cwd(), 'package.json'));
-  if (!license && packageJson.license) license = packageJson.license.toLowerCase();
-  
-  if (!user && packageJson.author) {
-    if (typeof packageJson.author === 'string') {
-      user = packageJson.author.replace(/<.+>/, '').replace(/\(.+\)/, '').trim();
-    } else if (typeof packageJson.author === 'object' && packageJson.author.name) {
-      user = packageJson.author.name;
+if (!license || !user) {
+  try {
+    const packageJson = require(path.join(process.cwd(), 'package.json'));
+    if (!license && packageJson.license) license = packageJson.license.toLowerCase();
+    
+    if (!user && packageJson.author) {
+      if (typeof packageJson.author === 'string') {
+        user = packageJson.author.replace(/<.+>/, '').replace(/\(.+\)/, '').trim();
+      } else if (typeof packageJson.author === 'object' && packageJson.author.name) {
+        user = packageJson.author.name;
+      }
     }
+  } catch (e) {
+    // Couldn't find package.json in current directory, nothing to do
   }
-} catch (e) {
-  // Couldn't find package.json in current directory, nothing to do
 }
 
 if (license) {


### PR DESCRIPTION
If someone's filled out their `package.json` before creating a LICENSE, then both author and license might be in there, so I think it would be nice to try reading from there if any required values are missing.

The license field is a bit of a problem though, since you'll usually see values like `MIT` or `Apache-2.0` instead of `mit` or `apache2`. I think this should be handled elsewhere, where values given via the `-l` flag can benefit from the mapping as well. I'll create an issue for that.