### PR TITLE
Use fullname and use correct version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@captainsafia/legit",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Automatically add a license to a GitHub project",
   "main": "index.js",
   "bin": {
@@ -21,7 +21,8 @@
   "dependencies": {
     "@captainsafia/commentator": "^1.1.0",
     "commander": "^2.9.0",
+    "fullname": "^3.3.0",
     "node-fetch": "^1.6.3",
-    "username": "^2.3.0"
+    "username": "^4.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,11 @@
 const fs = require('fs');
 const path = require('path');
 const program = require('commander');
+const fullname = require('fullname');
 const username = require('username');
 const placeholders = require('./placeholders');
 const commentator = require('@captainsafia/commentator');
+const packageInfo = require('../package.json');
 
 const licensesPath = path.join(__dirname, '/../licenses/');
 
@@ -16,7 +18,7 @@ function validateLicense(license) {
 }
 
 program
-  .version('2.0.0');
+  .version(packageInfo.version);
 
 program
   .command('list').alias('l')
@@ -34,10 +36,10 @@ program
   .option('-u --user [user]', 'The user/organization who holds the license')
   .option('-y --year [year]', 'The year the license is in effect')
   .description('Put a license in this directory')
-  .action(function(licenseArg) {
+  .action(async function(licenseArg) {
     const fileArg = this.file;
     const yearArg = this.year || new Date().getFullYear();
-    const userArg = this.user || username.sync();
+    const userArg = this.user || await fullname() || username.sync();
 
     const user = placeholders[licenseArg]['user'];
     const year = placeholders[licenseArg]['year'];


### PR DESCRIPTION
Hi 👋 

## What's Changed

This PR:
- Closes #22, and closes #25
- Adds ability to use the user's `fullname`, and keeps `username` as a fallback
- Uses correct version number for the `--version`, `-V` options. This will always be in sync with `package.json` moving forward.
- `3.0.0` → `3.1.0`

## Possible Caveat
Please note that the `fullname` package is Promise based, so I had to use async/await. Otherwise, I would have to change a lot of code to re-arrange the flow.

Async/await was introduced in node `7.6.0`, but I'm not sure what the minimal requirements for this package. So with this change, `legit` won't work in node environments prior to that.

Please let me know if that's okay! If so, I might also add an [`engines` option](https://docs.npmjs.com/files/package.json#engines) to the `package.json` file.