### PR TITLE
Add support for building snaps

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: legit
+base: core18 # the base snap is the execution environment for this snap
+version: git
+summary: Add licenses to projects at the command line 
+description: |
+  legit is a command line application that allows you to automagically generate 
+  a LICENSE file for the current working directory that you are in or a license 
+  header for a file where applicable.
+
+grade: stable
+confinement: strict
+
+parts:
+  legit:
+    plugin: nodejs
+    source: .
+
+
+apps:
+  legit:
+    command: legit
+    plugs:
+      - home
+      - removable-media
+      - network


### PR DESCRIPTION
Hi. I recently discovered legit. As someone who is very lazy about putting the correct licenses in things I make, this has made a real difference to me. So thank you for making it!

This pull request enables creation of a snap package of legit. The single snap (built for many architectures) in the Snap Store will be installable on numerous popular Linux distributions with no changes. It’ll also be discoverable via the [Snap Store](https://snapcraft.io/store), where releases are under your control.

If you're willing to publish this under the legit project name, you just need to [create an account](https://snapcraft.io/snaps) and then [register the legit name](https://snapcraft.io/register-snap).

A snap file created by snapcraft (our free software tool for building snaps) can then be released in the Snap Store with `snap push --release stable *.snap`. You'll want to install snapcraft (brew install snapcraft, snap install snapcraft, or apt install snapcraft) and login (snapcraft login) first, though.

You may also want to consider using [https://build.snapcraft.io/](https://build.snapcraft.io/) which is a free build service, that can create armhf, amd64, i386, arm64 and other builds of legit, and push them to the store automatically. Alternatively it’s possible to integrate publishing the snap via a third party CI system such as travis or circle-ci.

I appreciate snaps and snapcraft may be a new thing to you, so I’d be happy to answer any questions you may have.
